### PR TITLE
Create robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /


### PR DESCRIPTION
This PR adds a simple robots.txt so that crawlers don’t see a wonky Cloudflare error when trying to retrieve it. This file allows crawlers to hit every route, which should be fine for now considering we only have one.